### PR TITLE
Handle empty selection in GUI tree view

### DIFF
--- a/imprimir_cocina_win.py
+++ b/imprimir_cocina_win.py
@@ -554,7 +554,10 @@ if args.gui:
                 self.detail_text.delete('1.0', tk.END)
                 self.detail_text.configure(state=tk.DISABLED)
                 return
-            idx = int(selection[0])
+            try:
+                idx = int(selection[0])
+            except (TypeError, ValueError):
+                return
             payload = self.printed_orders[idx]
             self.detail_text.configure(state=tk.NORMAL)
             self.detail_text.delete('1.0', tk.END)
@@ -598,7 +601,11 @@ if args.gui:
             if not selection:
                 messagebox.showinfo("Reimprimir", "Seleccione una comanda de la lista.")
                 return
-            idx = int(selection[0])
+            try:
+                idx = int(selection[0])
+            except (TypeError, ValueError):
+                messagebox.showinfo("Reimprimir", "Seleccione una comanda de la lista.")
+                return
             payload = self.printed_orders[idx]
             if not payload.get('printed'):
                 messagebox.showinfo("Reimprimir", "Solo se pueden reimprimir comandas ya impresas.")


### PR DESCRIPTION
## Summary
- prevent detail and reprint actions from crashing when the tree selection is empty or invalid
- show a friendly message when reprint is requested without a valid selection

## Testing
- not run (GUI-focused change)

------
https://chatgpt.com/codex/tasks/task_e_68d5e7ec15fc832cbff6d10e4dc5d303