### PR TITLE
Fix order clause for recent printed fetch

### DIFF
--- a/imprimir_cocina_win.py
+++ b/imprimir_cocina_win.py
@@ -285,7 +285,7 @@ def fetch_recent_printed(pos_categ_id=None, limit_orders=20):
     line_ids = models.execute_kw(
         ODOO_DB, uid, ODOO_PWD,
         'pos.order.line', 'search',
-        [domain_lines], {'limit': max(50, limit_orders * 10), 'order': 'order_id.date_order desc, id desc'}
+        [domain_lines], {'limit': max(50, limit_orders * 10), 'order': 'write_date desc, id desc'}
     )
     if not line_ids:
         return []


### PR DESCRIPTION
## Summary
- replace the unsupported order clause used when fetching recent printed POS lines
- rely on write_date ordering before in-memory sorting of ticket payloads

## Testing
- not run (local environment lacks Odoo connectivity)

------
https://chatgpt.com/codex/tasks/task_e_68d61cc22b94832c8d119e09fbba5ce6